### PR TITLE
android.content.BroadcastReceiver on a null object reference

### DIFF
--- a/android/src/main/java/com/github/blueboytm/flutter_v2ray/FlutterV2rayPlugin.java
+++ b/android/src/main/java/com/github/blueboytm/flutter_v2ray/FlutterV2rayPlugin.java
@@ -107,10 +107,12 @@ public class FlutterV2rayPlugin implements FlutterPlugin, ActivityAware {
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-        vpnControlMethod.setMethodCallHandler(null);
-        vpnStatusEvent.setStreamHandler(null);
-        activity.unregisterReceiver(v2rayBroadCastReceiver);
-        executor.shutdown();
+        if (v2rayBroadCastReceiver != null) {
+            vpnControlMethod.setMethodCallHandler(null);
+            vpnStatusEvent.setStreamHandler(null);
+            activity.unregisterReceiver(v2rayBroadCastReceiver);
+            executor.shutdown();
+        }
     }
 
     @Override


### PR DESCRIPTION
Prevent throw and `Attempt to invoke virtual method 'void android.app.Activity.unregisterReceiver(android.content.BroadcastReceiver)' on a null object reference` error when we have other services or flutter libraries that have implemented the same service